### PR TITLE
Add specification for formatting of the output file

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -78,6 +78,7 @@ if __name__ == "__main__":
   argparser.add_argument("--q", help="Search term", default="let's play")
   argparser.add_argument("--max-results", help="Max results", default=25)
   argparser.add_argument("--output", help="Output filename", default="output.json")
+  argparser.add_argument("--format" help="Filename of JSON file describing attributes to output", default="format.json")
   args = argparser.parse_args()
 
   UTF8Writer = codecs.getwriter('utf8')

--- a/format-specifier.md
+++ b/format-specifier.md
@@ -55,6 +55,8 @@ videos `j` is an index specifying a valid offset within the array of videos.
 Attribute data is found by `data[i][subsource][name]` for `source=="channel"`, and
 by `data[i][videos][j][subsource][name]` for `source=="video"`.
 
+The specific per-type processing of attributes is as follows:
+
 ## `alias`
 
 Attributes of type `alias` are special in that they do not use the `source` or
@@ -88,7 +90,7 @@ An attibute of type `extracted` has the type-specific-argument `extraction`.
 
 `goal` is any type-specifier besides `alias`. If `goal` is "extracted", then
 another `extraction` object must be provided in the current one: this object may
-**not** have the same `source` as *any* `extraction` object it is contained in (no
+**not** have the same `source` as the `extraction` object it is contained in (no
 current `<source-specifier>` is complex enough that this would be of use anyway -
 If this changes, this requirement will be revisited). The type specifier of `goal`
 will replace the type specifier of the attibute once extraction is complete. If it
@@ -127,11 +129,13 @@ When the `source` of the attribute is "video", then the output will be:
 many of the values are the first
    - The string " (`labels[0]`/[`labels[0]`+`labels[1]`])" will be appended to the
 output attibute name.
+   - The output `type` will be changed to `numeric`.
  - For non-binary attributes (when labels doesn't have two values), a set of
 attributes, each of which is a decimal describing how many of the values are the
 corresponding label
    - The string " `labels[i]`"  will be appended to the output attribute name of
-the i^th output attribute.
+the i<sup>th</sup> output attribute.
+   - The output `type` will be changed to `numeric`.
 
 ## `stringConcat`
 

--- a/format-specifier.md
+++ b/format-specifier.md
@@ -1,0 +1,56 @@
+# Format.json format specifier
+
+Format.json is a JSON-compliant file which details which attributes should be put 
+in the output and how.
+
+It consists of an array of objects, where each object specifies one attribute.
+
+Each attribute object is as follows:`
+{
+    "name" : <string>,
+    "type" : <type-specifier>,
+    <type-specific-arguments>,
+    "source" : <string>,
+    "subsource" : <string>
+}`
+
+A `<type-specifier>` is one of:
+
+ - "string"
+
+ - "stringConcat"
+
+ - "numeric"
+
+ - "boolean"
+
+ - "nominal"
+
+ - "alias"
+
+ - "extracted"
+
+ - "datetime"
+
+Attributes are processed differently per-specifier. Details of these proceed later 
+in the document.
+
+The `name` of an attribute is passed on to the output. Additionally, for all type 
+specifiers except `alias`, it is the name used in the source file for the object 
+at the lowest level.
+
+The `source` of an attribute is either "channel" or "video". It is prepended to 
+the attribute name in the output, as "`source` - `name`". If it is "channel", the 
+subsource in the top-level of a source-file object will be used. If it is 
+"videos", the attribute will be collected over each object in the "videos" array 
+in the source-file, and merged into a single value (dependent on the type specifier).
+
+The `subsource` of an attribute is the name of the object, in the source-file 
+object being searched, where the attribute data is found.
+
+The attribute is therefore located as follows for non-`alias` types. Assume that 
+the source-file has been loaded into an object `data`, that `i` is an index 
+specifying a valid offset within the top-level array of `data`, and that for 
+videos `j` is an index specifying a valid offset within the array of videos. 
+Attribute data is found by `data[i][subsource][name]` for `source=="channel"`, and 
+by `data[i][videos][j][subsource][name]` for `source=="video"`.

--- a/format-specifier.md
+++ b/format-specifier.md
@@ -110,3 +110,25 @@ If the source specifier is "regex", then the attibute data in the source-file mu
 be a string, and the `specifier` parameter of the `extraction` object must be a 
 regular expression to run on the data in the source-file. The result of this 
 operation will be the result of the extraction, casted to the goal datatype.
+
+## `nominal` and `boolean`
+
+Attributes of type `nominal` are forwarded directly to the output file. They 
+must include the type-specific-argument "labels", which is an array of strings, 
+each of which is one possible value the attribute may take, and where the attibute 
+may never take a value which is not in `labels`.
+
+The type specifier `boolean` is shorthand for type `nominal` with labels `["true", 
+"false"]`.
+
+When the `source` of the attribute is "video", then the output will be:
+
+ - For binary attributes (when labels only has two values), a decimal describing how 
+many of the values are the first
+   - The string " (`labels[0]`/[`labels[0]+`labels[1]`])" will be appended to the 
+output attibute name.
+ - For non-binary attributes (when labels doesn't have two values), a set of 
+attributes, each of which is a decimal describing how many of the values are the 
+corresponding label
+   - The string " `labels[i]`"  will be appended to the output attribute name of 
+the i^th output attribute.

--- a/format-specifier.md
+++ b/format-specifier.md
@@ -142,3 +142,12 @@ between each value in the array of strings.
 
 When the `source` of the attribute is "video", the output will be merged and 
 deduplicated.
+
+## `string`
+
+Attributes of type `string` are strings which are forwarded directly to the output 
+file, and require no additional parameters.
+
+When the `source` of the attribute is "video", the values will be concatenated by 
+commas. Alternatively, a string delimiter can be supplied as the optional 
+"combine" attribute, and it will be used instead.

--- a/format-specifier.md
+++ b/format-specifier.md
@@ -132,3 +132,13 @@ attributes, each of which is a decimal describing how many of the values are the
 corresponding label
    - The string " `labels[i]`"  will be appended to the output attribute name of 
 the i^th output attribute.
+
+## `stringConcat`
+
+Attributes of type `stringConcat` concatenate an array of strings in the 
+source-file, and write the result to the output file as type `string`. They must 
+include the type-specific-argument "delimiter", which is a string placed in 
+between each value in the array of strings.
+
+When the `source` of the attribute is "video", the output will be merged and 
+deduplicated.

--- a/format-specifier.md
+++ b/format-specifier.md
@@ -125,7 +125,7 @@ When the `source` of the attribute is "video", then the output will be:
 
  - For binary attributes (when labels only has two values), a decimal describing how
 many of the values are the first
-   - The string " (`labels[0]`/[`labels[0]+`labels[1]`])" will be appended to the
+   - The string " (`labels[0]`/[`labels[0]`+`labels[1]`])" will be appended to the
 output attibute name.
  - For non-binary attributes (when labels doesn't have two values), a set of
 attributes, each of which is a decimal describing how many of the values are the

--- a/format-specifier.md
+++ b/format-specifier.md
@@ -1,6 +1,6 @@
 # Format.json format specifier
 
-Format.json is a JSON-compliant file which details which attributes should be put 
+Format.json is a JSON-compliant file which details which attributes should be put
 in the output and how.
 
 It consists of an array of objects, where each object specifies one attribute.
@@ -32,49 +32,49 @@ A `<type-specifier>` is one of:
 
  - "datetime"
 
-Attributes are processed differently per-specifier. Details of these proceed later 
+Attributes are processed differently per-specifier. Details of these proceed later
 in the document.
 
-The `name` of an attribute is passed on to the output. Additionally, for all type 
-specifiers except `alias`, it is the name used in the source file for the object 
+The `name` of an attribute is passed on to the output. Additionally, for all type
+specifiers except `alias`, it is the name used in the source file for the object
 at the lowest level.
 
-The `source` of an attribute is either "channel" or "video". It is prepended to 
-the attribute name in the output, as "`source` - `name`". If it is "channel", the 
-subsource in the top-level of a source-file object will be used. If it is 
-"videos", the attribute will be collected over each object in the "videos" array 
+The `source` of an attribute is either "channel" or "video". It is prepended to
+the attribute name in the output, as "`source` - `name`". If it is "channel", the
+subsource in the top-level of a source-file object will be used. If it is
+"videos", the attribute will be collected over each object in the "videos" array
 in the source-file, and merged into a single value (dependent on the type specifier).
 
-The `subsource` of an attribute is the name of the object, in the source-file 
+The `subsource` of an attribute is the name of the object, in the source-file
 object being searched, where the attribute data is found.
 
-The attribute is therefore located as follows for non-`alias` types. Assume that 
-the source-file has been loaded into an object `data`, that `i` is an index 
-specifying a valid offset within the top-level array of `data`, and that for 
-videos `j` is an index specifying a valid offset within the array of videos. 
-Attribute data is found by `data[i][subsource][name]` for `source=="channel"`, and 
+The attribute is therefore located as follows for non-`alias` types. Assume that
+the source-file has been loaded into an object `data`, that `i` is an index
+specifying a valid offset within the top-level array of `data`, and that for
+videos `j` is an index specifying a valid offset within the array of videos.
+Attribute data is found by `data[i][subsource][name]` for `source=="channel"`, and
 by `data[i][videos][j][subsource][name]` for `source=="video"`.
 
 ## `alias`
 
-Attributes of type `alias` are special in that they do not use the `source` or 
-`subsource` attributes. An attribute of type `alias` takes on the value of a 
-target attribute, which is not itself written into the output, with the new name 
-specified by `name`. An attribute of type `alias` is specified by three 
-parameters: The always-required `name` and `type`, and the type-specific-argument 
+Attributes of type `alias` are special in that they do not use the `source` or
+`subsource` attributes. An attribute of type `alias` takes on the value of a
+target attribute, which is not itself written into the output, with the new name
+specified by `name`. An attribute of type `alias` is specified by three
+parameters: The always-required `name` and `type`, and the type-specific-argument
 `target`, where `target` is an attribute object of any type besides `alias`.
 
-Note that because `alias` does not use the `source` argument, the `name` given 
-will be written to the output file as-is. `alias` attributes which need to include 
+Note that because `alias` does not use the `source` argument, the `name` given
+will be written to the output file as-is. `alias` attributes which need to include
 the video/channel tag therefore need to have it in their `name`.
 
 ## `extracted`
 
-Attributes of type `extracted` are those which are processed (more than 
-`stringConcat`) before being written into the output. In particular, they are 
-those where the desired data isn't exactly what is written in the source-file. Two 
-examples of this are data within strings: "THIS IS A VALUE: 'abc' THAT WAS A 
-VALUE", or when the desired output is some metadata of the source-file attribute 
+Attributes of type `extracted` are those which are processed (more than
+`stringConcat`) before being written into the output. In particular, they are
+those where the desired data isn't exactly what is written in the source-file. Two
+examples of this are data within strings: "THIS IS A VALUE: 'abc' THAT WAS A
+VALUE", or when the desired output is some metadata of the source-file attribute
 (for example, the length of the string).
 
 An attibute of type `extracted` has the type-specific-argument `extraction`.
@@ -86,79 +86,79 @@ An attibute of type `extracted` has the type-specific-argument `extraction`.
     "specifier" : <optional string>
 }`
 
-`goal` is any type-specifier besides `alias`. If `goal` is "extracted", then 
-another `extraction` object must be provided in the current one: this object may 
-**not** have the same `source` as *any* `extraction` object it is contained in (no 
-current `<source-specifier>` is complex enough that this would be of use anyway - 
-If this changes, this requirement will be revisited). The type specifier of `goal` 
-will replace the type specifier of the attibute once extraction is complete. If it 
-is `extracted`, then this process will be repeated (more deeply-nested extractions 
-will be performed later). Otherwise, the attibute will continue processing as the 
+`goal` is any type-specifier besides `alias`. If `goal` is "extracted", then
+another `extraction` object must be provided in the current one: this object may
+**not** have the same `source` as *any* `extraction` object it is contained in (no
+current `<source-specifier>` is complex enough that this would be of use anyway -
+If this changes, this requirement will be revisited). The type specifier of `goal`
+will replace the type specifier of the attibute once extraction is complete. If it
+is `extracted`, then this process will be repeated (more deeply-nested extractions
+will be performed later). Otherwise, the attibute will continue processing as the
 specified type.
 
 A `<source-specifier>` is one of the following:
 
  - "stringLength"
- 
+
  - "regex"
- 
-If the source specifier is "stringLength", then `goal` must be `numeric`, and the 
-attibute data in the source-file must be a string. The result will simply be the 
+
+If the source specifier is "stringLength", then `goal` must be `numeric`, and the
+attibute data in the source-file must be a string. The result will simply be the
 length (number of characters in) the string.
 
-If the source specifier is "regex", then the attibute data in the source-file must 
-be a string, and the `specifier` parameter of the `extraction` object must be a 
-regular expression to run on the data in the source-file. The result of this 
+If the source specifier is "regex", then the attibute data in the source-file must
+be a string, and the `specifier` parameter of the `extraction` object must be a
+regular expression to run on the data in the source-file. The result of this
 operation will be the result of the extraction, casted to the goal datatype.
 
 ## `nominal` and `boolean`
 
-Attributes of type `nominal` are forwarded directly to the output file. They 
-must include the type-specific-argument "labels", which is an array of strings, 
-each of which is one possible value the attribute may take, and where the attibute 
+Attributes of type `nominal` are forwarded directly to the output file. They
+must include the type-specific-argument "labels", which is an array of strings,
+each of which is one possible value the attribute may take, and where the attibute
 may never take a value which is not in `labels`.
 
-The type specifier `boolean` is shorthand for type `nominal` with labels `["true", 
+The type specifier `boolean` is shorthand for type `nominal` with labels `["true",
 "false"]`.
 
 When the `source` of the attribute is "video", then the output will be:
 
- - For binary attributes (when labels only has two values), a decimal describing how 
+ - For binary attributes (when labels only has two values), a decimal describing how
 many of the values are the first
-   - The string " (`labels[0]`/[`labels[0]+`labels[1]`])" will be appended to the 
+   - The string " (`labels[0]`/[`labels[0]+`labels[1]`])" will be appended to the
 output attibute name.
- - For non-binary attributes (when labels doesn't have two values), a set of 
-attributes, each of which is a decimal describing how many of the values are the 
+ - For non-binary attributes (when labels doesn't have two values), a set of
+attributes, each of which is a decimal describing how many of the values are the
 corresponding label
-   - The string " `labels[i]`"  will be appended to the output attribute name of 
+   - The string " `labels[i]`"  will be appended to the output attribute name of
 the i^th output attribute.
 
 ## `stringConcat`
 
-Attributes of type `stringConcat` concatenate an array of strings in the 
-source-file, and write the result to the output file as type `string`. They must 
-include the type-specific-argument "delimiter", which is a string placed in 
+Attributes of type `stringConcat` concatenate an array of strings in the
+source-file, and write the result to the output file as type `string`. They must
+include the type-specific-argument "delimiter", which is a string placed in
 between each value in the array of strings.
 
-When the `source` of the attribute is "video", the output will be merged and 
+When the `source` of the attribute is "video", the output will be merged and
 deduplicated.
 
 ## `string`
 
-Attributes of type `string` are strings which are forwarded directly to the output 
+Attributes of type `string` are strings which are forwarded directly to the output
 file, and require no additional parameters.
 
-When the `source` of the attribute is "video", the values will be concatenated by 
-commas. Alternatively, a string delimiter can be supplied as the optional 
+When the `source` of the attribute is "video", the values will be concatenated by
+commas. Alternatively, a string delimiter can be supplied as the optional
 "combine" attribute, and it will be used instead.
 
 ## `numeric`
 
-Attributes of type `numeric` are numbers which are forwarded directly to the 
+Attributes of type `numeric` are numbers which are forwarded directly to the
 output file, and require no additional parameters.
 
-When the `source` of attribute is "video", the average of the values will be 
-written. Alternatively, an alternative combiner can be supplied as the optional 
+When the `source` of attribute is "video", the average of the values will be
+written. Alternatively, an alternative combiner can be supplied as the optional
 "combine" attribute, and it will be used instead. Valid combiners are:
 
  - "average"
@@ -166,30 +166,30 @@ written. Alternatively, an alternative combiner can be supplied as the optional
  - "sum"
    - Writes the sum of values
  - "stringify"
-   - Converts each value into a string, then concatenates with commas and writes 
+   - Converts each value into a string, then concatenates with commas and writes
 the result (changes output `type` to "string").
  - "stringifyDedup"
-   - Converts each value into a string, deduplicates, then concatenates with 
+   - Converts each value into a string, deduplicates, then concatenates with
 commas and writes the result (changes output `type` to "string").
 
 ## `datetime`
 
-Attributes of type `datetime` are dates or times ideally under the ISO-8601 
-datetime format. They are read into a Python date object and output as ISO-8601 to 
-ensure compliance with that standard. It is therefore only recommended that they 
-are given as ISO-8601: Any format which can be parsed by the [python-dateutil 
+Attributes of type `datetime` are dates or times ideally under the ISO 8601
+datetime format. They are read into a Python date object and output as ISO 8601 to
+ensure compliance with that standard. It is therefore only recommended that they
+are given as ISO 8601: Any format which can be parsed by the [python-dateutil
 library](http://labix.org/python-dateutil) is valid.
 
-When the `source` of the attribute is `video`, the average of the values (as 
-performed by averaging UNIX timestamps) will be used. Alternatively, an 
-alternative combiner may be supplied as the optional "combine" attibute, and it 
+When the `source` of the attribute is `video`, the average of the values (as
+performed by averaging UNIX timestamps) will be used. Alternatively, an
+alternative combiner may be supplied as the optional "combine" attibute, and it
 will be used instead. Valid combiners are:
 
  - "average"
    - Default behavior, writes the average of values.
  - "stringify"
-   - Converts each value into a string, then concatenates with commas and writes 
+   - Converts each value into a string, then concatenates with commas and writes
 the result (changes output `type` to "string").
  - "stringifyDedup"
-   - Converts each value into a string, deduplicates, then concatenates with 
+   - Converts each value into a string, deduplicates, then concatenates with
 commas and writes the result (changes output `type` to "string").

--- a/format-specifier.md
+++ b/format-specifier.md
@@ -67,3 +67,46 @@ parameters: The always-required `name` and `type`, and the type-specific-argumen
 Note that because `alias` does not use the `source` argument, the `name` given 
 will be written to the output file as-is. `alias` attributes which need to include 
 the video/channel tag therefore need to have it in their `name`.
+
+## `extracted`
+
+Attributes of type `extracted` are those which are processed (more than 
+`stringConcat`) before being written into the output. In particular, they are 
+those where the desired data isn't exactly what is written in the source-file. Two 
+examples of this are data within strings: "THIS IS A VALUE: 'abc' THAT WAS A 
+VALUE", or when the desired output is some metadata of the source-file attribute 
+(for example, the length of the string).
+
+An attibute of type `extracted` has the type-specific-argument `extraction`.
+
+`extraction` is an object in the following format:`
+{
+    "goal" : <type-specifier>,
+    "source" : <source-specifier>,
+    "specifier" : <optional string>
+}`
+
+`goal` is any type-specifier besides `alias`. If `goal` is "extracted", then 
+another `extraction` object must be provided in the current one: this object may 
+**not** have the same `source` as *any* `extraction` object it is contained in (no 
+current `<source-specifier>` is complex enough that this would be of use anyway - 
+If this changes, this requirement will be revisited). The type specifier of `goal` 
+will replace the type specifier of the attibute once extraction is complete. If it 
+is `extracted`, then this process will be repeated (more deeply-nested extractions 
+will be performed later). Otherwise, the attibute will continue processing as the 
+specified type.
+
+A `<source-specifier>` is one of the following:
+
+ - "stringLength"
+ 
+ - "regex"
+ 
+If the source specifier is "stringLength", then `goal` must be `numeric`, and the 
+attibute data in the source-file must be a string. The result will simply be the 
+length (number of characters in) the string.
+
+If the source specifier is "regex", then the attibute data in the source-file must 
+be a string, and the `specifier` parameter of the `extraction` object must be a 
+regular expression to run on the data in the source-file. The result of this 
+operation will be the result of the extraction, casted to the goal datatype.

--- a/format-specifier.md
+++ b/format-specifier.md
@@ -151,3 +151,23 @@ file, and require no additional parameters.
 When the `source` of the attribute is "video", the values will be concatenated by 
 commas. Alternatively, a string delimiter can be supplied as the optional 
 "combine" attribute, and it will be used instead.
+
+## `numeric`
+
+Attributes of type `numeric` are numbers which are forwarded directly to the 
+output file, and require no additional parameters.
+
+When the `source` of attribute is "video", the average of the values will be 
+written. Alternatively, an alternative combiner can be supplied as the optional 
+"combine" attribute, and it will be used instead. Valid combiners are:
+
+ - "average"
+   - Default behavior, writes the average of values.
+ - "sum"
+   - Writes the sum of values
+ - "stringify"
+   - Converts each value into a string, then concatenates with commas and writes 
+the result (changes output `type` to "string").
+ - "stringifyDedup"
+   - Converts each value into a string, deduplicates, then concatenates with 
+commas and writes the result (changes output `type` to "string").

--- a/format-specifier.md
+++ b/format-specifier.md
@@ -54,3 +54,16 @@ specifying a valid offset within the top-level array of `data`, and that for
 videos `j` is an index specifying a valid offset within the array of videos. 
 Attribute data is found by `data[i][subsource][name]` for `source=="channel"`, and 
 by `data[i][videos][j][subsource][name]` for `source=="video"`.
+
+## `alias`
+
+Attributes of type `alias` are special in that they do not use the `source` or 
+`subsource` attributes. An attribute of type `alias` takes on the value of a 
+target attribute, which is not itself written into the output, with the new name 
+specified by `name`. An attribute of type `alias` is specified by three 
+parameters: The always-required `name` and `type`, and the type-specific-argument 
+`target`, where `target` is an attribute object of any type besides `alias`.
+
+Note that because `alias` does not use the `source` argument, the `name` given 
+will be written to the output file as-is. `alias` attributes which need to include 
+the video/channel tag therefore need to have it in their `name`.

--- a/format-specifier.md
+++ b/format-specifier.md
@@ -171,3 +171,25 @@ the result (changes output `type` to "string").
  - "stringifyDedup"
    - Converts each value into a string, deduplicates, then concatenates with 
 commas and writes the result (changes output `type` to "string").
+
+## `datetime`
+
+Attributes of type `datetime` are dates or times ideally under the ISO-8601 
+datetime format. They are read into a Python date object and output as ISO-8601 to 
+ensure compliance with that standard. It is therefore only recommended that they 
+are given as ISO-8601: Any format which can be parsed by the [python-dateutil 
+library](http://labix.org/python-dateutil) is valid.
+
+When the `source` of the attribute is `video`, the average of the values (as 
+performed by averaging UNIX timestamps) will be used. Alternatively, an 
+alternative combiner may be supplied as the optional "combine" attibute, and it 
+will be used instead. Valid combiners are:
+
+ - "average"
+   - Default behavior, writes the average of values.
+ - "stringify"
+   - Converts each value into a string, then concatenates with commas and writes 
+the result (changes output `type` to "string").
+ - "stringifyDedup"
+   - Converts each value into a string, deduplicates, then concatenates with 
+commas and writes the result (changes output `type` to "string").

--- a/format.json
+++ b/format.json
@@ -1,0 +1,178 @@
+[
+    {
+        "name" : "topicIds",
+        "type" : "stringConcat",
+        "delimiter" : ",",
+        "source" : "channel",
+        "subsource" : "topicDetails"
+    },
+    {
+        "name" : "topicCategories",
+        "type" : "stringConcat",
+        "delimiter" : ",",
+        "source" : "channel",
+        "subsource" : "topicDetails"
+    },
+    {
+        "name" : "commentCount",
+        "type" : "numeric",
+        "source" : "channel",
+        "subsource" : "statistics"
+    },
+    {
+        "name" : "viewCount",
+        "type" : "numeric",
+        "source" : "channel",
+        "subsource" : "statistics"
+    },
+    {
+        "name" : "videoCount",
+        "type" : "numeric",
+        "source" : "channel",
+        "subsource" : "statistics"
+    },
+    {
+        "name" : "subscriberCount",
+        "type" : "numeric",
+        "source" : "channel",
+        "subsource" : "statistics"
+    },
+    {
+        "name" : "hiddenSubscriberCount",
+        "type" : "boolean",
+        "source" : "channel",
+        "subsource" : "statistics"
+    },
+    {
+        "name" : "topicCategories",
+        "type" : "stringConcat",
+        "delimiter" : ",",
+        "source" : "video",
+        "subsource" : "topicDetails"
+    },
+    {
+        "name" : "relevantTopicIds",
+        "type" : "stringConcat",
+        "delimiter" : ",",
+        "source" : "video",
+        "subsource" : "topicDetails"
+    },
+    {
+        "name" : "commentCount",
+        "type" : "numeric",
+        "source" : "video",
+        "subsource" : "statistics"
+    },
+    {
+        "name" : "viewCount",
+        "type" : "numeric",
+        "source" : "video",
+        "subsource" : "statistics"
+    },
+    {
+        "name" : "favoriteCount",
+        "type" : "numeric",
+        "source" : "video",
+        "subsource" : "statistics"
+    },
+    {
+        "name" : "dislikeCount",
+        "type" : "numeric",
+        "source" : "video",
+        "subsource" : "statistics"
+    },
+    {
+        "name" : "likeCount",
+        "type" : "numeric",
+        "source" : "video",
+        "subsource" : "statistics"
+    },
+    {
+        "name" : "definition",
+        "type" : "nominal",
+        "labels" : [
+            "sd",
+            "hd"
+        ],
+        "source" : "video",
+        "subsource" : "contentDetails"
+    },
+    {
+        "name" : "projection",
+        "type" : "nominal",
+        "labels" : [
+            "360",
+            "rectangular"
+        ],
+        "source" : "video",
+        "subsource" : "contentDetails"
+    },
+    {
+        "name" : "caption",
+        "type" : "boolean",
+        "source" : "video",
+        "subsource" : "contentDetails"
+    },
+    {
+        "name" : "duration",
+        "type" : "datetime",
+        "source" : "video",
+        "subsource" : "contentDetails"
+    },
+    {
+        "name" : "licensedContent",
+        "type" : "boolean",
+        "source" : "video",
+        "subsource" : "contentDetails"
+    },
+    {
+        "name" : "dimension",
+        "type" : "nominal",
+        "labels" : [
+            "3d",
+            "2d"
+        ],
+        "source" : "video",
+        "subsource" : "contentDetails"
+    },
+    {
+        "name" : "video - titleLength",
+        "type" : "alias",
+        "target" : {
+            "name" : "title",
+            "type" : "extracted",
+            "extraction" : {
+                "goal" : "numeric",
+                "source" : "stringLength"
+            },
+            "source" : "video",
+            "subsource" : "snippet"
+        }
+    },
+    {
+        "name" : "video - descriptionLength",
+        "type" : "alias",
+        "target" : {
+            "name" : "description",
+            "type" : "extracted",
+            "extraction" : {
+                "goal" : "numeric",
+                "source" : "stringLength"
+            },
+            "source" : "video",
+            "subsource" : "snippet"
+        }
+    },
+    {
+        "name" : "publishedAt",
+        "type" : "datetime",
+        "source" : "video",
+        "subsource" : "snippet"
+    },
+    {
+        "name" : "tags",
+        "type" : "stringConcat",
+        "source" : "video",
+        "subsource" : "snippet"
+    }
+]


### PR DESCRIPTION
No code implemented as of yet, but this tells us what we need to do, which pieces it should be done in, and once the fetcher is able to handle the `format.json` file to generate a header, it should be fairly simple to process the YouTube data into a Weka-compliant file - The specification is written in such a way that output can be generated Weka-compliant (only Weka datatypes are output).

The only important omission is the "class" attribute Weka uses in the header. I was thinking we could add a commandline argument to set which attribute is the default class attribute... But it may need to be a customization of the `extracted` type, because we want it to be a combination of multiple attributes. That needs discussing.

Please review and tell me what you think.